### PR TITLE
Add Bonobo to the streaming category

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ multi-processor, multi-core machines
 * [VoltDB](https://voltdb.com/)
 * [PipelineDB](https://github.com/pipelinedb/pipelinedb) The Streaming SQL Database https://www.pipelinedb.com
 * [Spring Cloud Dataflow](http://cloud.spring.io/spring-cloud-dataflow/) Streaming and tasks execution between Spring Boot apps
+* [Bonobo](https://www.bonobo-project.org/) Bonobo is a data-processing toolkit for python 3.5+
 
 # Batch Processing
 * [Hadoop MapReduce](http://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html) Hadoop MapReduce is a software framework for easily writing applications which process vast amounts of data (multi-terabyte data-sets) in-parallel on large clusters (thousands of nodes) of commodity hardware in a reliable, fault-tolerant manner


### PR DESCRIPTION
Bonobo is a lightweight Extract-Transform-Load (ETL) framework for Python 3.5+.

I included it into the streaming category because Bonobo processes the data as streams of independent rows. Each node handles one line at a time, but the nodes run in parallel.

Check https://www.bonobo-project.org/

