### PR TITLE
Adding The Data Stack Show Podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,4 @@
 ### Podcasts
 
 - [Data Engineering Podcast](https://www.dataengineeringpodcast.com/) - The show about modern data infrastructure.
+- [The Data Stack Show](https://datastackshow.com/) - A show where they talk to data engineers, analysts, and data scientists about their experience around building and maintaining data infrastructure, delivering data and data products, and driving better outcomes across their businesses with data.


### PR DESCRIPTION
This adds the `The Data Stack Show` podcast to the list which talks to data engineers about various tools and processes.