### PR TITLE
Adding in DataComPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Contents
 
 - [Databases](#databases)
+- [Data Comparison](#data-comparison)
 - [Data Ingestion](#data-ingestion)
 - [File System](#file-system)
 - [Serialization format](#serialization-format)
@@ -95,6 +96,10 @@
   - [cayley](https://github.com/cayleygraph/cayley) - An open-source graph database. Google.
   - [Snappydata](https://github.com/SnappyDataInc/snappydata) - SnappyData: OLTP + OLAP Database built on Apache Spark.
   - [TimescaleDB](https://www.timescale.com/) - Built as an extension on top of PostgreSQL, TimescaleDB is a time-series SQL database providing fast analytics, scalability, with automated data management on a proven storage engine.
+
+## Data Comparison
+
+- [datacompy](https://github.com/capitalone/datacompy) - DataComPy is a Python library that facilitates the comparison of two DataFrames in pandas, Polars, Spark and more. The library goes beyond basic equality checks by providing detailed insights into discrepancies at both row and column levels. 
 
 ## Data Ingestion
 


### PR DESCRIPTION
Adding in a Data Comparison section:

- Adding link to: https://github.com/capitalone/datacompy

DataComPy allows users to compare different types of dataframes and types. Currently, it supports Pandas, Spark, Polars, and Fugue. [Fugue](https://github.com/fugue-project/fugue) extends functionality and allows cross type compares (spark vs pandas, dask vs duckdb etc)