### PR TITLE
Add Gradient by Sync to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@
   - [Snappydata](https://github.com/SnappyDataInc/snappydata) - SnappyData: OLTP + OLAP Database built on Apache Spark.
   - [TimescaleDB](https://www.timescale.com/) - Built as an extension on top of PostgreSQL, TimescaleDB is a time-series SQL database providing fast analytics, scalability, with automated data management on a proven storage engine.
 
+## Databricks cluster management
+
+- [Gradient](https://synccomputing.com/) - Automated cluster management for Databricks. Gradient by Sync uses an advanced ML algorithm to contionusly optimize your workspace, saving you 50% on your bill while meeting SLAs. 
+
 ## Data Comparison
 
 - [datacompy](https://github.com/capitalone/datacompy) - DataComPy is a Python library that facilitates the comparison of two DataFrames in pandas, Polars, Spark and more. The library goes beyond basic equality checks by providing detailed insights into discrepancies at both row and column levels.


### PR DESCRIPTION
Adding Gradient by Sync to the list and creating a new category for services that help platform engineers and data engineers to optimize infrastructure costs. 