### PR TITLE
Add Pathway

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 - [Kuiper](https://github.com/emqx/kuiper) - An edge lightweight IoT data analytics/streaming software implemented by Golang, and it can be run at all kinds of resource-constrained edge devices.
 - [Zilla](https://github.com/aklivity/zilla) - - An API gateway built for event-driven architectures and streaming that supports standard protocols such as HTTP, SSE, gRPC, MQTT, and the native Kafka protocol.
 - [SwimOS](https://github.com/swimos/swim-rust) - A framework for building real-time streaming data processing applications that supports a wide range of ingestion sources.
+- [Pathway](https://github.com/pathwaycom/pathway): Performant open-source Python ETL framework with Rust runtime, supporting 300+ data sources.
 
 ## Batch Processing
 


### PR DESCRIPTION
This PR adds the Pathway framework to the "Stream Processing" section of the list.
The framework provides solid ELT/ETL capabilities and is used by a number of institutions, including Transdev, the public mobility company, and La Poste, the French national postal service.