### PR TITLE
Add ingestr to Data Ingestion section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 
 ## Data Ingestion
 
+- [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases with a single command. Supports 50+ sources including Postgres, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.
 - [Kafka](https://kafka.apache.org/) - Publish-subscribe messaging rethought as a distributed commit log.
   - [BottledWater](https://github.com/confluentinc/bottledwater-pg) - Change data capture from PostgreSQL into Kafka. Deprecated.
   - [kafkat](https://github.com/airbnb/kafkat) - Simplified command-line administration for Kafka brokers.


### PR DESCRIPTION
## Summary
- Add [ingestr](https://github.com/bruin-data/ingestr) to the Data Ingestion section

ingestr is a CLI tool to copy data between databases with a single command. Supports 50+ sources including Postgres, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.

## Test plan
- [x] Link works and goes to the correct repository
- [x] Description is accurate and follows the list format

🤖 Generated with [Claude Code](https://claude.com/claude-code)