### PR TITLE
Add kreuzberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - [CsvPath Framework](https://www.csvpath.org/) - A delimited data preboarding framework that fills the gap between MFT and the data lake.
 - [Estuary Flow](https://estuary.dev) - No/low-code data pipeline platform that handles both batch and real-time data ingestion.
 - [db2lake](https://github.com/bahador-r/db2lake) - Lightweight Node.js ETL framework for databases → data lakes/warehouses.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) - Polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, Go, and more. Extracts text, tables, and metadata from 62+ document formats for data pipeline ingestion.
 
 ## File System
 


### PR DESCRIPTION
Adds [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) to the Data Ingestion section.

Kreuzberg is a polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, Go, and more. It extracts text, tables, and metadata from 62+ document formats, making it useful for data pipeline ingestion workflows.