### PR TITLE
Add Signals CLI to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@
 
 - [Prometheus.io](https://github.com/prometheus/prometheus) - An open-source service monitoring system and time series database.
 - [HAProxy Exporter](https://github.com/prometheus/haproxy_exporter) - Simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption.
+- [Signals CLI](https://github.com/sortlist/signals-cli) - Intent signal monitoring CLI. Track LinkedIn engagers, keyword posters, job changers, funding events. JSON output for data pipelines.
 
 ## Profiling
 


### PR DESCRIPTION
CLI tool for intent signal monitoring:

- **Signals CLI** — Monitor LinkedIn engagers, keyword posters, job changers, funding events. JSON output for data pipelines.

- npm: [signals-sortlist-cli](https://www.npmjs.com/package/signals-sortlist-cli)
- https://github.com/sortlist/signals-cli