### PR TITLE
Add Mindweave Synthetic Business Data to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [Common Crawl](https://commoncrawl.org/) - Open source repository of web crawl data.
 - [Wikipedia](https://dumps.wikimedia.org/enwiki/latest/) - Wikipedia's complete copy of all wikis, in the form of Wikitext source and metadata embedded in XML. A number of raw database tables in SQL form are also available.
 - [FirstData](https://github.com/MLT-OSS/FirstData) - The world's most comprehensive authoritative data source knowledge base. 160+ curated sources from governments, international organizations, and research institutions with MCP integration.
+- [Mindweave Synthetic Business Data](https://github.com/MindweaveTech/sme-sim-sample) - 42-table synthetic SME dataset with double-entry accounting, tax compliance (AU/US/UK), and temporal realism. CSV, SQL, Parquet, SQLite. Ideal for ETL pipeline testing.
 
 ## Monitoring
 


### PR DESCRIPTION
Adds Mindweave Synthetic Business Data to the Data Dumps section.

**42-table synthetic SME dataset** ideal for ETL pipeline testing:
- Double-entry accounting (debits = credits)
- 44 foreign key relationships across 7 business domains
- Tax compliance for AU, US, UK
- Available in CSV, SQL (PostgreSQL), Parquet, SQLite
- 3-year day-by-day business simulation

GitHub: https://github.com/MindweaveTech/sme-sim-sample