### PR TITLE
Add PFC-JSONL - JSONL log compressor with DuckDB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@
 - [ProtoBuf](https://github.com/protocolbuffers/protobuf) - Protocol Buffers - Google's data interchange format.
 - [SequenceFile](https://wiki.apache.org/hadoop/SequenceFile) - A flat file consisting of binary key/value pairs. It is extensively used in MapReduce as input/output formats.
 - [Kryo](https://github.com/EsotericSoftware/kryo) - A fast and efficient object graph serialization framework for Java.
+- [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing and DuckDB integration. Achieves ~9% compression ratio (better than gzip) with time-range random access queries.
 
 ## Stream Processing
 


### PR DESCRIPTION
Adds [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl), a specialized JSONL log compressor with block-level timestamp indexing.

- ~9% compression ratio (vs gzip ~12%, zstd ~14%)
- DuckDB queryable: `INSTALL pfc FROM community; LOAD pfc;`
- Fluent Bit compatible (pfc-fluentbit forwarder)
- pfc-migrate for migrating existing gzip/bz2/zstd archives