### PR TITLE
Add LinkedIn Jobs Scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [Arpe.io](https://www.arpe.io/) - High-speed CLI tools for database export, import, replication and migration with parallel streaming to CSV, Parquet, JSON and cloud storage, supporting PostgreSQL, MySQL, Oracle, SQL Server and 80+ sources.
 - [Crustdata](https://crustdata.com) - A real-time B2B data API for company and people intelligence, providing firmographics, headcount signals, job listings, web traffic, and funding events via REST API and webhooks for data enrichment pipelines.
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
+- [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 
 ## File System
 


### PR DESCRIPTION
Adds a Crawlee-based LinkedIn job listing scraper to the data ingestion section. Extracts structured job data (title, company, location, description, apply URL) at scale without API keys. Deployed on Apify with free tier available.