### PR TITLE
Add DataSpoc Pipe to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 
 ## Data Ingestion
 
+- [DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) - Data ingestion engine that connects 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure). Streaming, incremental, with auto-catalog.
 - [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases with a single command. Supports 50+ sources including PostgreSQL, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.
 - [Kafka](https://kafka.apache.org/) - Publish-subscribe messaging rethought as a distributed commit log.
   - [BottledWater](https://github.com/confluentinc/bottledwater-pg) - Change data capture from PostgreSQL into Kafka. Deprecated.


### PR DESCRIPTION
[DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) is an open-source (Apache 2.0) data ingestion engine that connects any of the 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure).

- **PyPI**: https://pypi.org/project/dataspoc-pipe/
- **License**: Apache 2.0
- Streaming ingestion, incremental extraction, auto-catalog
- CLI-first, no infrastructure required

Added to the Data Ingestion section in alphabetical order.