### PR TITLE
Add pdfmux to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [Estuary Flow](https://estuary.dev) - No/low-code data pipeline platform that handles both batch and real-time data ingestion.
 - [db2lake](https://github.com/bahador-r/db2lake) - Lightweight Node.js ETL framework for databases → data lakes/warehouses.
 - [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) - Polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, Go, and more. Extracts text, tables, and metadata from 62+ document formats for data pipeline ingestion.
+- [pdfmux](https://github.com/NameetP/pdfmux) - Python PDF-to-Markdown orchestrator. Classifies each page and routes to the optimal backend (PyMuPDF, Docling, RapidOCR, Gemini Flash), emitting Markdown plus a per-page confidence score so ingestion pipelines can quarantine low-trust pages before feeding LLMs or retrieval.
 - [DataRaven](https://dataraven.io/) - Managed cloud object storage transfers for ingestion workflows.
 - [Xquik](https://xquik.com) - Real-time X (Twitter) data extraction platform with REST API (76 endpoints), 20 bulk extraction tools, account monitoring, HMAC-signed webhooks, and MCP server for AI agent integration.
 - [Arpe.io](https://www.arpe.io/) - High-speed CLI tools for database export, import, replication and migration with parallel streaming to CSV, Parquet, JSON and cloud storage, supporting PostgreSQL, MySQL, Oracle, SQL Server and 80+ sources.


### PR DESCRIPTION
Adding [pdfmux](https://github.com/NameetP/pdfmux) under **Data Ingestion**.

### What it is
A Python orchestrator for document ingestion pipelines. It classifies each PDF page (digital text, scanned, tables, mixed) and routes it to the optimal extractor — PyMuPDF for digital text, Docling for tables, RapidOCR for scans, Gemini Flash for hard pages. Emits Markdown plus a **per-page confidence score** so ingestion pipelines can quarantine low-trust pages before feeding LLMs or retrieval systems.

### Why it fits this list
- **Data Ingestion category already includes Kreuzberg** (polyglot document intelligence) — pdfmux is a direct peer, solving the same problem with a different approach (per-page routing + confidence gating vs. monolithic extraction).
- **Production-oriented**: structured error codes, type hints, active CI, semver releases, 151 tests, 6 releases since launch. MIT licensed.
- **Benchmarked** on 1,422 pages across 11 real-world business documents.

### Quick facts
- PyPI: `pip install pdfmux`
- Repo: https://github.com/NameetP/pdfmux
- Docs: https://pdfmux.com