### PR TITLE
Add AI Dev Jobs to Community > Forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@
 
 - [/r/dataengineering](https://www.reddit.com/r/dataengineering/) - News, tips, and background on Data Engineering.
 - [/r/etl](https://www.reddit.com/r/ETL/) - Subreddit focused on ETL.
+- [AI Dev Jobs](https://aidevboard.com) - Job board focused on AI, ML, and data engineering roles with 7,400+ listings, salary data, and a free REST API.
 
 ### Conferences
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Community > Forums section.

AI Dev Jobs is a job board focused on AI, ML, and data engineering roles with:
- 7,400+ job listings from 400+ companies
- Salary data and analytics
- Free REST API for programmatic access
- Useful for data engineers exploring AI/ML career paths