### PR TITLE
Add stratif.io to Charts and Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@
 - [Apache Superset](https://github.com/apache/incubator-superset) - A modern, enterprise-ready business intelligence web application.
 - [Redash](https://redash.io/) - Make Your Company Data Driven. Connect to any data source, easily visualize and share your data.
 - [Metabase](https://github.com/metabase/metabase) - The easy, open source way for everyone in your company to ask questions and learn from data.
+- [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and paths directly on DuckDB, Postgres, Snowflake, or ClickHouse.
 - [PyQtGraph](https://www.pyqtgraph.org/) - A pure-python graphics and GUI library built on PyQt4 / PySide and numpy. It is intended for use in mathematics / scientific / engineering applications.
 - [Seaborn](https://seaborn.pydata.org) - A Python visualization library based on matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
 - [QueryGPT](https://github.com/MKY508/QueryGPT) - Natural language database query interface with automatic chart generation, supporting Chinese and English queries.


### PR DESCRIPTION
Adds stratif.io alongside Superset, Redash, and Metabase in Charts and Dashboards.

stratif.io is an open-source (Apache-2.0), self-hosted, warehouse-native product analytics tool. It runs funnels, retention, and path analysis directly on an existing SQL warehouse (DuckDB, Postgres, Snowflake, ClickHouse, Databricks) — no ingestion pipeline, no tracking SDK.

Repo: https://github.com/stratif-io/stratif.io