### PR TITLE
Add SlothDB to Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
   - [Snappydata](https://github.com/SnappyDataInc/snappydata) - OLTP + OLAP Database built on Apache Spark.
   - [TimescaleDB](https://www.timescale.com/) - Built as an extension on top of PostgreSQL, TimescaleDB is a time-series SQL database providing fast analytics, scalability, with automated data management on a proven storage engine.
   - [DuckDB](https://duckdb.org/) - A fast in-process analytical database that has zero external dependencies, runs on Linux/macOS/Windows, offers a rich SQL dialect, and is free and extensible.
+  - [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - In-process analytical SQL database written in C++20. Reads Parquet, CSV, JSON, Avro, Arrow, SQLite, and Excel directly. Single binary, Python package, and 1.3 MB WASM build for the browser.
 
 ## Data Comparison
 


### PR DESCRIPTION
Adds SlothDB next to DuckDB in the Databases section.

Repo: https://github.com/SouravRoy-ETL/slothdb
Site: https://slothdb.org

Embedded analytical SQL database written from scratch in C++20.
Reads seven file formats (Parquet, CSV, JSON, Avro, Arrow, SQLite,
Excel) in the core binary. Ships as a single binary, a Python
package, and a 1.3 MB WASM build that runs in the browser. MIT.