### PR TITLE
Add rawquery to Data Lake Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@
 - [Ilum](https://ilum.cloud/) - A modular Data Lakehouse platform that simplifies the management and monitoring of Apache Spark clusters across Kubernetes and Hadoop environments.
 - [Gravitino](https://github.com/apache/gravitino) - An open-source, unified metadata management for data lakes, data warehouses, and external catalogs.
 - [FlightPath Data](https://www.flightpathdata.com) - FlightPath is a gateway to a data lake's bronze layer, protecting it from invalid external data file feeds as a trusted publisher.
+- [rawquery](https://rawquery.dev) - Managed lakehouse platform on Apache Iceberg with DuckDB query compute, S3 storage, Postgres wire protocol, and SQL transforms.
 
 ## ELK Elastic Logstash Kibana
 


### PR DESCRIPTION
Adds rawquery to the Data Lake Management section.

[rawquery](https://rawquery.dev) is a managed lakehouse platform built on Apache Iceberg with DuckDB as the query engine. Storage is S3, the catalog is Nessie, and clients connect via the Postgres wire protocol, a CLI, or a Python/REST API. SQL transforms run as scheduled DAGs.

Sits naturally next to lakeFS, Nessie, and Gravitino — same data-lake management space, packaged as a managed service.

Docs: https://rawquery.dev/docs