### PR TITLE
Add data-genie to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [CsvPath Framework](https://www.csvpath.org/) - A delimited data preboarding framework that fills the gap between MFT and the data lake.
 - [Estuary Flow](https://estuary.dev) - No/low-code data pipeline platform that handles both batch and real-time data ingestion.
 - [db2lake](https://github.com/bahador-r/db2lake) - Lightweight Node.js ETL framework for databases → data lakes/warehouses.
+- [data-genie](https://github.com/pujansrt/data-genie) - High-performance, streaming-first ETL engine for Node.js and TypeScript with constant memory footprint.
 - [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) - Polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, Go, and more. Extracts text, tables, and metadata from 62+ document formats for data pipeline ingestion.
 - [DataRaven](https://dataraven.io/) - Managed cloud object storage transfers for ingestion workflows.
 - [Xquik](https://xquik.com) - Real-time X (Twitter) data extraction platform with REST API (76 endpoints), 20 bulk extraction tools, account monitoring, HMAC-signed webhooks, and MCP server for AI agent integration.


### PR DESCRIPTION
Added [data-genie](https://github.com/pujansrt/data-genie), a high-performance streaming-first ETL engine for Node.js and TypeScript. It's designed for O(1) memory footprint when processing massive datasets.