### PR TITLE
Add Scherlok to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [DataKitchen](https://datakitchen.io/) -  Open Source Data Observability for end-to-end Data Journey Observability, data profiling, anomaly detection, and auto-created data quality validation tests.
 - [GreatExpectation](https://greatexpectations.io/) -  Open Source data validation framework to manage data quality. Users can define and document “expectations” rules about how data should look and behave.
 - [Provero](https://github.com/provero-org/provero) - A vendor-neutral, declarative data quality engine. Define checks in YAML, run anywhere. Includes 16 built-in check types, SQL batch optimizer, anomaly detection, and data contracts.
+- [Scherlok](https://github.com/rbmuller/scherlok) - Zero-config data quality CLI. Profiles every table on first run, then auto-detects anomalies (volume drops, schema drift, freshness misses, distribution shifts) on subsequent runs. No YAML, no rules to write. Works with Postgres, BigQuery, Snowflake, and dbt.
 - [RunSQL](https://runsql.com/) - Free online SQL playground for MySQL, PostgreSQL, and SQL Server. Create database structures, run queries, and share results instantly.
 - [Spark Playground](https://www.sparkplayground.com/) - Write, run, and test PySpark code on Spark Playground's online compiler. Access real-world sample datasets & solve interview questions to enhance your PySpark skills for data engineering roles.
 - [daffy](https://github.com/vertti/daffy/) - Decorator-first DataFrame contracts/validation (columns/dtypes/constraints) at function boundaries. Supports Pandas/Polars/PyArrow/Modin.


### PR DESCRIPTION
Adds [Scherlok](https://github.com/rbmuller/scherlok) to the **Testing** section, alphabetically after [Provero](https://github.com/provero-org/provero).

## What it is

Open-source CLI for data quality monitoring. Inverts the rules-first model: profiles every table on first run, stores the baseline, then auto-detects when subsequent runs diverge. No YAML, no rules to define.

Catches volume drops/spikes, schema drift, freshness misses, NULL surges, distribution shifts, cardinality changes — each auto-scored CRITICAL / WARNING / INFO via z-scores. Pure Python, no ML, no telemetry.

## Why it fits this list

The Testing section already lists rule-based tools (Great Expectations, DQOps, Provero). Scherlok is the closest cousin among existing entries but takes the opposite design path — learn the baseline, detect drift, no rules — making it complementary rather than redundant.

Three commands:

\`\`\`bash
scherlok connect postgres://user:pass@host/db
scherlok investigate
scherlok watch
\`\`\`

Adapter support: Postgres, BigQuery, Snowflake. First-class dbt integration (\`scherlok dbt --project-dir\` reads \`target/manifest.json\` and profiles each materialized model post-\`dbt run\`).

## Status

- v0.5.0 on [PyPI](https://pypi.org/project/scherlok/)
- 207 tests, MIT licensed
- Active maintenance — first external PR landed within 24h of v0.5.0

Happy to adjust the wording or position if you'd like.