### PR TITLE
Add Enrich.sh to data ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 ## Data Ingestion
 
 - [DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) - Data ingestion engine that connects 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure). Streaming, incremental, with auto-catalog.
+- [Enrich.sh](https://enrich.sh) - Managed event ingestion service that converts JSON sent to a REST API into Hive-partitioned Parquet on Cloudflare R2, queryable from DuckDB, ClickHouse, BigQuery, Snowflake, and Python.
 - [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases with a single command. Supports 50+ sources including PostgreSQL, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.
 - [Kafka](https://kafka.apache.org/) - Publish-subscribe messaging rethought as a distributed commit log.
   - [BottledWater](https://github.com/confluentinc/bottledwater-pg) - Change data capture from PostgreSQL into Kafka. Deprecated.


### PR DESCRIPTION
Enrich.sh is a managed event ingestion service that writes JSON events to Hive-partitioned Parquet files on Cloudflare R2, designed for teams that need reliable event capture without running Kafka, Confluent, or a broker. It belongs in the Data Ingestion section alongside Kafka and ingestr, since it covers the same job (moving event data into durable, queryable storage), with a different architecture (object storage and Parquet instead of a broker and topics). The output is standard Parquet, so it composes naturally with the warehouses and query engines already on this list, including DuckDB, ClickHouse, Spark, and Snowflake. 