### PR TITLE
Add CARQ project to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@
 - [Crustdata](https://crustdata.com) - A real-time B2B data API for company and people intelligence, providing firmographics, headcount signals, job listings, web traffic, and funding events via REST API and webhooks for data enrichment pipelines.
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
+- [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
 
 ## File System
 


### PR DESCRIPTION
Hello! I am submitting an individual pull request to add a new tool to the Data Ingestion category.

**Tool:** CARQ (Context-Aware RAG Processing Queue)
**Category:** Data Ingestion

**Why it is useful for Data Engineering:**
As data engineering teams increasingly handle unstructured data ingestion for Generative AI (RAG pipelines), managing API rate limits during document embedding becomes a major bottleneck. CARQ is a production-grade ingestion queue that solves this. It prevents 429 rate-limit cascades using adaptive backoff and circuit breakers.

To keep the infrastructure footprint light for data teams, it uses a zero-external-broker architecture, relying entirely on PostgreSQL (and pgvector) for the async task queue, state management, and vector storage.

Thank you for reviewing!