### PR TITLE
Add The Quiet-Broke Index to Data Dumps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@
 - [GitHub Archive](https://www.gharchive.org/) - GitHub's public timeline since 2011, updated every hour.
 - [Common Crawl](https://commoncrawl.org/) - Open source repository of web crawl data.
 - [Wikipedia](https://dumps.wikimedia.org/enwiki/latest/) - Wikipedia's complete copy of all wikis, in the form of Wikitext source and metadata embedded in XML. A number of raw database tables in SQL form are also available.
+- [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite of US household cost burdens (housing, taxes, childcare, healthcare, transport) aggregated from Census ACS, BLS Consumer Expenditure Survey, and HUD Fair Market Rents. Open methodology, free, no email gate.
 - [FirstData](https://github.com/MLT-OSS/FirstData) - The world's most comprehensive authoritative data source knowledge base. 160+ curated sources from governments, international organizations, and research institutions with MCP integration.
 - [Mindweave Synthetic Business Data](https://github.com/MindweaveTech/sme-sim-sample) - 42-table synthetic SME dataset with double-entry accounting, tax compliance (AU/US/UK), and temporal realism. CSV, SQL, Parquet, SQLite. Ideal for ETL pipeline testing.
 


### PR DESCRIPTION
## What is this?

**[The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/)** is an aggregated public dataset tool that combines five open government data sources to produce a 30-metro composite index of US household cost burdens.

**Source datasets:**
- US Census American Community Survey (ACS) — housing costs
- BLS Consumer Expenditure Survey — healthcare and transport
- HUD Fair Market Rents — rental cost benchmarks
- Tax Foundation — federal/state/local tax burden by state
- State-level childcare cost surveys

## Why it fits the Data Dumps section

Data engineers building cost-of-living pipelines, location intelligence tools, or HR compensation systems frequently need aggregated metro-level cost data. This tool:

- Is free and ungated (no API key, no email, no paywall)
- Has an [open methodology page](https://jeevesagency.github.io/quiet-broke-index/methodology.html) documenting all sources, weights, and assumptions
- Covers 30 major US metros
- Aggregates data that otherwise requires pulling and normalizing from 5 different government sources

## Entry added

Added to the **Data Dumps** section:

```
- [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite of US household cost burdens (housing, taxes, childcare, healthcare, transport) aggregated from Census ACS, BLS Consumer Expenditure Survey, and HUD Fair Market Rents. Open methodology, free, no email gate.
```