### PR TITLE
Add GeoSQL to Charts and Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@
 - [Seaborn](https://seaborn.pydata.org) - A Python visualization library based on matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
 - [QueryGPT](https://github.com/MKY508/QueryGPT) - Natural language database query interface with automatic chart generation, supporting Chinese and English queries.
 - [AI for Database](https://aifordatabase.com/) - Agentic AI platform to connect any database (PostgreSQL, MySQL, MongoDB, etc.) and query in plain English; includes self-refreshing intelligent dashboards and action workflows triggered by data changes.
+- [GeoSQL](https://github.com/dekart-xyz/geosql) - Claude/Codex skill for cost-safe geospatial SQL on BigQuery and Snowflake.
 
 ## Workflow
 


### PR DESCRIPTION
Adds [GeoSQL](https://github.com/dekart-xyz/geosql) to Charts and Dashboards. Claude/Codex skill for cost-safe geospatial SQL on BigQuery and Snowflake.

Disclosure: I'm the author/maintainer of GeoSQL.