### PR TITLE
Add chDB to Databases > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
   - [TimescaleDB](https://www.timescale.com/) - Built as an extension on top of PostgreSQL, TimescaleDB is a time-series SQL database providing fast analytics, scalability, with automated data management on a proven storage engine.
   - [DuckDB](https://duckdb.org/) - A fast in-process analytical database that has zero external dependencies, runs on Linux/macOS/Windows, offers a rich SQL dialect, and is free and extensible.
   - [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - In-process analytical SQL database written in C++20. Reads Parquet, CSV, JSON, Avro, Arrow, SQLite, and Excel directly. Single binary, Python package, and 1.3 MB WASM build for the browser.
+  - [chDB](https://chdb.io) - Embedded ClickHouse — full ClickHouse SQL dialect, ~80 data formats, and 12+ source connectors (S3, Postgres, MongoDB, Kafka, Iceberg) in core. Python, Go, Rust, Node, Bun, Zig, and Ruby bindings.
 
 ## Data Comparison
 


### PR DESCRIPTION
Adds chDB to the `Databases > Other` subsection, alongside DuckDB and SlothDB (also in-process analytical engines).

chDB embeds the full ClickHouse SQL engine in your application process — same SQL dialect as ClickHouse, ~80 data formats, and 12+ source connectors in core. Bindings for Python, Go, Rust, Node, Bun, Zig, and Ruby.

- Homepage: https://chdb.io
- GitHub: https://github.com/chdb-io/chdb
- License: Apache-2.0