### PR TITLE
Add Amazonscraperapi to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
+- [Amazonscraperapi](https://amazonscraperapi.com) - Amazon product, search, and batch scraping API with residential proxies, REST endpoints and an MCP server for AI agent integration. 1000 free requests, then usage-based pricing.
 
 ## File System
 


### PR DESCRIPTION
Adding Amazonscraperapi to the Data Ingestion section. It's a managed REST API for pulling structured product data from Amazon (product detail, search, batch) backed by a residential proxy stack, with an MCP server for AI agent integration. 1000 free requests on signup, usage-based pricing after.

- Homepage: https://amazonscraperapi.com
- Docs: https://amazonscraperapi.com/docs
- MCP server: https://www.npmjs.com/package/amazon-scraper-api-mcp
- Status: Production, free tier available without credit card