### PR TITLE
Add data-contract-cite to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@
 - [DataScreenIQ](https://datascreeniq.com) - Real-time data quality firewall for pipelines and APIs. Screens rows in milliseconds for schema drift, null spikes, type mismatches, and data anomalies with PASS / WARN / BLOCK decisions.
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.
 - [Fixzi](https://fixzi.ai) - JSON/XML validation and API contract monitoring tool for debugging and testing structured data.
+- [data-contract-cite](https://github.com/plusultra-tools/data-contract-cite) - Verbatim-cited data-contract validator for regulated data pipelines. Emits compliance manifest mapping each contract assertion to the regulation that authorises it (GDPR, EU Data Act, HIPAA).
 
 ## Community
 


### PR DESCRIPTION
Adds [data-contract-cite](https://github.com/plusultra-tools/data-contract-cite), an MIT-licensed Python CLI for regulated data pipelines.

What it does: takes a data contract (YAML schema + assertion list) and emits a compliance manifest that maps each assertion to the verbatim text of the regulation that authorises or requires it (GDPR Art. 5/9, EU Data Act Art. 4-5, HIPAA Safe Harbor). The manifest is hash-chained against a per-assertion audit log so a regulator can verify integrity from the JSON alone.

Differs from the existing Testing-section tools by carrying the regulatory citation as a first-class output, which matters for pipelines crossing data-protection boundaries (cross-site research, cross-border B2B, regulated industries). Disclosure: I am the author. Placed alphabetically near Fixzi (last entry). 68 tests pass, ruff + mypy strict clean.