### PR TITLE
Add OrionBelt Semantic Layer to Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
 ## Workflow
 
 - [Bonnard](https://bonnard.dev/) - Agent-native semantic layer with governed metrics, React SDK, and multi-warehouse support. Connects AI agents and dashboards to a single source of truth.
+- [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML-defined dimensions, measures, and metrics into optimized SQL across 8 engines (BigQuery, ClickHouse, Databricks, Dremio, DuckDB, MySQL, PostgreSQL, Snowflake). Unified REST, MCP, and Postgres wire protocol; one model powers AI agents, analytics, DQ rules, and KPIs.
 - [Bruin](https://github.com/bruin-data/bruin) - End-to-end data pipeline tool that combines ingestion, transformation (SQL + Python), and data quality in a single CLI. Connects to BigQuery, Snowflake, PostgreSQL, Redshift, and more. Includes VS Code extension with live previews.
 - [Luigi](https://github.com/spotify/luigi) - A Python module that helps you build complex pipelines of batch jobs.
 - [CronQ](https://github.com/seatgeek/cronq) - An application cron-like system. [Used](https://chairnerd.seatgeek.com/building-out-the-seatgeek-data-pipeline/) w/Luigi. Deprecated.


### PR DESCRIPTION
Adds [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) (OBSL) to the **Workflow** section.

## What it is

OBSL is an open-source semantic sidecar: define dimensions, measures, metrics, and business rules in declarative YAML; compile them to optimized SQL across 8 engines (BigQuery, ClickHouse, Databricks, Dremio, DuckDB, MySQL, PostgreSQL, Snowflake) and execute via REST API, MCP server, or Postgres wire protocol. One model powers AI agents, analytics workflows, DQ checks, regulatory and business KPIs, and reporting.

## Position in the list

Placed right after Bonnard (the other agent-native semantic layer in the Workflow section) for thematic grouping. The list isn't strictly alphabetical so adjacency on topic feels right; happy to move it if you prefer a different position.

## Project status

- Active (v2.7.6 released this week).
- BSL-1.1 licensed.
- 2300+ tests, full CI.
- Live demo, docs site, PyPI, Docker Hub, MCP server.

Disclosure: I am the maintainer of OrionBelt.