### PR TITLE
Add Awareness to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
+- [Awareness](https://github.com/nazmiefearmutcu/awareness) - Local-first public-text ingestion engine. Backfills from Common Crawl + FineWeb and live-tails RSS / sitemaps / GDELT into Apache Iceberg, queryable from DuckDB. Single Python process, no cluster required.
 
 ## File System
 


### PR DESCRIPTION
Adding [Awareness](https://github.com/nazmiefearmutcu/awareness) to the **Data Ingestion** section.

A local-first public-text ingestion engine for the public web. It backfills any historical date range from Common Crawl + HuggingFace FineWeb, and live-tails RSS / sitemaps / GDELT for fresh items. Stores everything as Apache Iceberg on local disk, queryable from DuckDB (or any Iceberg-aware engine).

Differentiators vs. existing entries:
- Single Python process — no Spark, no Kafka, no cloud account required
- Iceberg-on-laptop pattern: time-travel + schema evolution, plug into bigger engines later without rewriting
- Polite by default: robots.txt respect, exponential backoff, conditional GETs
- v0.1.0 released, MIT licensed, full Research Workbench UI ships with the FastAPI control surface