### PR TITLE
Add Rawbbit to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
-- [Rawbbit](https://rawbbit.one/) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
+- [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 
 ## File System
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
+- [Rawbbit](https://rawbbit.one/) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 
 ## File System
 


### PR DESCRIPTION
Adding Rawbbit, an open-source self-hosted analytics pipeline.

**Project:** https://rawbbit.one/
**Source code:** https://github.com/mirlan-irokez/rawbbit
**License:** Apache 2.0
**Language:** Python

**Why "Data Ingestion" section:**
Rawbbit is fundamentally an event ingestion pipeline. The architecture: HTTP collector receives events → NATS JetStream buffers durably → writer service lands events as partitioned Parquet files in your own object storage (GCS, S3, or any S3-compatible backend). Downstream querying is decoupled — BigQuery external tables on top of the Parquet, or any tool that reads Parquet.

This makes it the closest match to other tools in this section like Airbyte, Meltano, and Estuary Flow — focused on data movement and ingestion, not orchestration (Workflow section) or storage (File System section).

**Why it fits this list:**
- Apache 2.0 licensed, fully self-hostable in user's own cloud account
- No telemetry, no vendor calls home
- Active development with recent commits
- Useful succinct description following the list's format
- Designed for data engineers, not marketers

**Checklist (per contributing.md):**
- [x] Searched previous suggestions — no duplicate
- [x] Useful content with good succinct description
- [x] Only alphanumeric text, no emojis or images
- [x] Added to the bottom of the Data Ingestion category
- [x] Format: `[List Name](link) - description`
- [x] Capitalized title
- [x] Checked spelling and grammar
- [x] No trailing whitespace
- [x] Link back included in our README (Inspired by section)
- [x] Individual PR for this single suggestion

Happy to address any feedback.