### PR TITLE
Add Duckle to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
+- [Duckle](https://github.com/SouravRoy-ETL/duckle) - Open-source visual ETL/ELT studio that compiles a drag-and-drop canvas to plain DuckDB SQL, with 300+ connectors (Snowflake, Oracle, SQL Server, Postgres, Excel, Parquet, REST) and a built-in MCP server for generating and running pipelines from natural language.
 
 ## File System
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@
 - [crdt-merge](https://github.com/mgillr/crdt-merge) - Conflict-free merge for DataFrames, JSON, ML models & distributed agents — powered by CRDTs.
 - [LinkedIn Jobs Scraper](https://apify.com/cryptosignals/linkedin-jobs-scraper) - Crawlee-based actor extracting structured LinkedIn job listings at scale without API keys.
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
-- [Duckle](https://github.com/SouravRoy-ETL/duckle) - Open-source visual ETL/ELT studio that compiles a drag-and-drop canvas to plain DuckDB SQL, with 300+ connectors (Snowflake, Oracle, SQL Server, Postgres, Excel, Parquet, REST) and a built-in MCP server for generating and running pipelines from natural language.
+- [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 
 ## File System
 


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) under **Data Ingestion**.

Duckle is an open-source visual ETL/ELT studio that runs on DuckDB: you build a drag-and-drop canvas of sources, transforms and sinks and it compiles to plain DuckDB SQL. It sits alongside existing open-source integration tools in this section (Airbyte, Meltano, dlt, Sling, Embulk).

Open source (Apache-2.0 / MIT), 300+ connectors, with a built-in MCP server.