### PR TITLE
Add enrich-companies - CSV company data enrichment CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 
 - [DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) - Data ingestion engine that connects 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure). Streaming, incremental, with auto-catalog.
 - [Enrich.sh](https://enrich.sh) - Managed event ingestion service that converts JSON sent to a REST API into Hive-partitioned Parquet on Cloudflare R2, queryable from DuckDB, ClickHouse, BigQuery, Snowflake, and Python.
+- [enrich-companies](https://github.com/Alessandro114/enrich-companies) - CLI tool to enrich CSV files with company data (financials, contacts, metadata) from 250M+ company records. Available on [npm](https://www.npmjs.com/package/enrich-companies).
 - [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases with a single command. Supports 50+ sources including PostgreSQL, MySQL, MongoDB, Salesforce, Shopify to any data warehouse.
 - [Kafka](https://kafka.apache.org/) - Publish-subscribe messaging rethought as a distributed commit log.
   - [BottledWater](https://github.com/confluentinc/bottledwater-pg) - Change data capture from PostgreSQL into Kafka. Deprecated.


### PR DESCRIPTION
## What is enrich-companies?

[enrich-companies](https://github.com/Alessandro114/enrich-companies) is an open-source CLI tool (available on [npm](https://www.npmjs.com/package/enrich-companies)) that enriches CSV files with company data — financials, contacts, and metadata — sourced from a database of 250M+ company records.

## Why it fits this list

The Data Ingestion section already includes similar CLI-based data tools like `ingestr`, `Sling`, and enrichment services like `Enrich.sh` and `Crustdata`. `enrich-companies` fills a specific niche: taking an existing CSV of companies and augmenting it with structured business data, which is a common step in data engineering pipelines for B2B analytics, lead scoring, and master data management.

## Changes

- Added one entry to the **Data Ingestion** section, following the existing formatting conventions.