### PR TITLE
Add LatAm Synth to Datasets/Data Dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 - [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite of US household cost burdens (housing, taxes, childcare, healthcare, transport) aggregated from Census ACS, BLS Consumer Expenditure Survey, and HUD Fair Market Rents. Open methodology, free, no email gate.
 - [FirstData](https://github.com/MLT-OSS/FirstData) - The world's most comprehensive authoritative data source knowledge base. 160+ curated sources from governments, international organizations, and research institutions with MCP integration.
 - [Mindweave Synthetic Business Data](https://github.com/MindweaveTech/sme-sim-sample) - 42-table synthetic SME dataset with double-entry accounting, tax compliance (AU/US/UK), and temporal realism. CSV, SQL, Parquet, SQLite. Ideal for ETL pipeline testing.
+- [LatAm Synth](https://apify.com/jmendozapuche/latam-synth) - Synthetic financial savings behavior generator for Latin America: users, savings goals, and transactions calibrated on 506K real records (2015–2024). Reproducible by seed, 100% synthetic.
 
 ## Monitoring
 


### PR DESCRIPTION
## What

Adds LatAm Synth under Datasets → Data Dumps.

## Why it fits

LatAm Synth generates synthetic datasets of financial savings behavior for
Latin America — the same niche as the existing "Mindweave Synthetic Business
Data" entry in this section. It produces three linked tables (users, savings
goals, deposit/withdrawal transactions) calibrated on 506K real records
(2015–2024).

Useful for data engineering pipelines that need realistic financial fixtures
for testing, ML training, or benchmarking without real PII.

Published on Apify (API-accessible, no setup required):
https://apify.com/jmendozapuche/latam-synth