### PR TITLE
Add zvec to Databases > Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
   - [DuckDB](https://duckdb.org/) - A fast in-process analytical database that has zero external dependencies, runs on Linux/macOS/Windows, offers a rich SQL dialect, and is free and extensible.
   - [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - In-process analytical SQL database written in C++20. Reads Parquet, CSV, JSON, Avro, Arrow, SQLite, and Excel directly. Single binary, Python package, and 1.3 MB WASM build for the browser.
   - [chDB](https://chdb.io) - Embedded ClickHouse — full ClickHouse SQL dialect, ~80 data formats, and 12+ source connectors (S3, Postgres, MongoDB, Kafka, Iceberg) in core. Python, Go, Rust, Node, Bun, Zig, and Ruby bindings.
+  - [zvec](https://github.com/alibaba/zvec) - An embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
 
 ## Data Comparison
 


### PR DESCRIPTION
## Project: [zvec](https://github.com/alibaba/zvec)

Zvec is an open-source embedded vector database by Alibaba Tongyi Lab — the SQLite of vector databases. It runs in-process with zero external dependencies, just `pip install zvec`.

### Why it fits here

- Embedded, in-process database with zero-config deployment
- 12,500+ GitHub stars, actively maintained (latest: v0.5.1, June 2026)
- Built on Alibaba production-proven Proxima engine
- Python SDK (`pip install zvec`) plus Go, Rust, and Dart bindings
- Fills the vector database gap in this awesome list