### PR TITLE
Add Nika (AI workflow engine) to Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@
 ## Workflow
 
 - [Bonnard](https://bonnard.dev/) - Governed, multi-tenant MCP access to your customers' data. Turn your warehouse, dbt, or semantic layer into a secure, per-customer MCP for AI agents.
+- [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI data pipelines: reviewable YAML DAGs statically checked (schema, permits, cost floor) before execution, with tamper-evident run traces.
 - [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML-defined dimensions, measures, and metrics into optimized SQL across 8 engines (BigQuery, ClickHouse, Databricks, Dremio, DuckDB, MySQL, PostgreSQL, Snowflake). Unified REST, MCP, and Postgres wire protocol; one model powers AI agents, analytics, DQ rules, and KPIs.
 - [Bruin](https://github.com/bruin-data/bruin) - End-to-end data pipeline tool that combines ingestion, transformation (SQL + Python), and data quality in a single CLI. Connects to BigQuery, Snowflake, PostgreSQL, Redshift, and more. Includes VS Code extension with live previews.
 - [DataFlow](https://github.com/OpenDCAI/DataFlow) - Open-source platform for data preparation, synthetic data generation, and AI/data pipelines. Includes reusable skills for automating workflow steps across data and AI tasks.


### PR DESCRIPTION
Adds **Nika** (alphabetical, house format).

Intent-as-code workflow engine for AI in a single Rust binary (AGPL-3.0): repeated AI work becomes a reviewable `.nika.yaml` DAG — statically checked (schema, permits, honest cost floor) before any token is spent, executed budget-capped with tamper-evident traces. Local-first providers (Ollama, llama.cpp, vLLM) plus cloud; ships a read-only MCP oracle, a VS Code extension and a GitHub Action.

Disclosure: I'm the author.
