### PR TITLE
Add ematix-flow to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
+- [ematix-flow](https://ematix.dev) - All-in-one Python framework for data pipelines, batch or streaming, scheduled or event-driven, with a built-in query engine, data-quality checks, and an operator web UI. Single binary, no cluster to run; Rust and Apache Arrow under the hood.
 
 ## File System
 


### PR DESCRIPTION
Adds **ematix-flow** to the Data Ingestion category.

[ematix-flow](https://ematix.dev) is an open-source, all-in-one Python framework for data pipelines — batch or streaming, scheduled or event-driven — with a built-in query engine, data-quality checks, and an operator web UI. It ships as a single binary with no cluster service to run; Rust and Apache Arrow under the hood.

- Docs: https://ematix.dev
- Source: https://github.com/ryan-evans-git/ematix-flow
- PyPI: https://pypi.org/project/ematix-flow/

The entry is added to the bottom of the Data Ingestion category, uses the `[Name](link) - Description.` format, and contains alphanumeric text only per the contributing guidelines.