### PR TITLE
Add ParquetKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 - [SequenceFile](https://wiki.apache.org/hadoop/SequenceFile) - A flat file consisting of binary key/value pairs. It is extensively used in MapReduce as input/output formats.
 - [Kryo](https://github.com/EsotericSoftware/kryo) - A fast and efficient object graph serialization framework for Java.
 - [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing and DuckDB integration. Achieves ~9% compression ratio (better than gzip) with time-range random access queries.
+- [ParquetKit](https://parquetkit.com) - Browser-based viewer, SQL workbench and converter for Parquet files powered by DuckDB-WASM. Fully client-side, no upload.
 
 ## Stream Processing
 


### PR DESCRIPTION
**What it is**: [ParquetKit](https://parquetkit.com) — a browser-based viewer, SQL workbench and converter for Parquet files, powered by DuckDB-WASM.

**Why it fits**: added under Serialization format next to the other Parquet tooling — useful for inspecting and converting Parquet files without any install.

MIT licensed: https://github.com/XxxKMSxxX/parquetkit