### PR TITLE
Add faucet-stream to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
+- [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data pipeline toolkit for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
 
 ## File System
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@
 - [CARQ](https://github.com/whispering3/CARQ) - Context-Aware RAG Processing Queue for high availability and adaptive rate-limiting.
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
-- [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data pipeline toolkit for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
+- [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
 
 ## File System
 


### PR DESCRIPTION
Adds [faucet-stream](https://github.com/PawanSikawat/faucet-stream) to the Data Ingestion section (appended to the bottom of the list, per the contributing guidelines). faucet-stream is a config-driven data-movement platform for Rust — pluggable source and sink connectors run declaratively from YAML/JSON by a single binary, or embedded as a library; handles ETL, CDC, and streaming. Individual PR for this single suggestion; one-sentence description, capital start / period end, no emojis (awesome-lint compliant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)