### PR TITLE
Add h5i-db to Databases > Timeseries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
   - [Dalmatiner DB](https://github.com/dalmatinerdb/dalmatinerdb) - Fast distributed metrics database.
   - [Blueflood](https://github.com/rackerlabs/blueflood) - A distributed system designed to ingest and process time series data.
   - [Timely](https://github.com/NationalSecurityAgency/timely) - A time series database application that provides secure access to time series data based on Accumulo and Grafana.
+  - [h5i-db](https://github.com/h5i-dev/h5i-db) - Embedded versioned time series database written in Rust. Stores Parquet, queries it with DataFusion SQL plus ASOF joins and time bucketing, and makes every write an atomic commit so any past version reads in constant time.
 - Other
   - [Tarantool](https://github.com/tarantool/tarantool/) - An in-memory database and application server.
   - [GreenPlum](https://github.com/greenplum-db/gpdb) - The Greenplum Database (GPDB) - An advanced, fully featured, open source data warehouse. It provides powerful and rapid analytics on petabyte scale data volumes.


### PR DESCRIPTION
Adds **h5i-db** to the bottom of the Databases > Timeseries category.

**What it is:** an embedded, versioned time series database written in Rust, with a Python package and a CLI. It stores Parquet and queries it through DataFusion SQL, adding time series operators on top: ASOF join, timezone aware time bucketing, gapfill and resample, rolling windows.

**Why it fits:** the existing Timeseries entries are all server or cluster systems. h5i-db covers the in-process end of the same category, the way DuckDB does for general analytics: one directory, no server, no daemon. What is distinct is that storage is immutable and versioned, so every write is an atomic commit, any past version reads in constant time, and a bad ingest is one restore away from undone. Reads can also be pinned to a decision time, which bounds a query to data that had actually arrived by that instant.

Apache-2.0, published on crates.io and PyPI, documented at https://db.h5i.dev/manual/ with usage examples in the README.

Single suggestion, added to the bottom of the relevant category, no emojis or images in the entry. Disclosure: I am the author.
