### PR TITLE
Add Agentsor File to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@
 - [DataScreenIQ](https://datascreeniq.com) - Real-time data quality firewall for pipelines and APIs. Screens rows in milliseconds for schema drift, null spikes, type mismatches, and data anomalies with PASS / WARN / BLOCK decisions.
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.
 - [Fixzi](https://fixzi.ai) - JSON/XML validation and API contract monitoring tool for debugging and testing structured data.
+- [Agentsor File Contracts](https://github.com/linkoinsight/agentsor-file) - An MIT-licensed Python CLI for local CSV and Parquet schema, freshness, row-count, and file-size checks with optional missed-run monitoring.
 
 ## Community
 


### PR DESCRIPTION
Adds Agentsor File Contracts to the Testing section.

Why it fits: it is an MIT-licensed Python CLI that checks completed CSV and Parquet files locally against explicit schema, freshness, row-count, and file-size contracts. Optional hosted receipts add missed-run detection without uploading the file.

Guideline check:
- One suggestion in this PR.
- Added at the bottom of the relevant category.
- No existing Agentsor entry or pull request was found.
- Description is concise and the project link is publicly accessible.

Affiliation disclosure: this submission comes from the project maintainer account.