### PR TITLE
Add Infino to Databases > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
   - [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - In-process analytical SQL database written in C++20. Reads Parquet, CSV, JSON, Avro, Arrow, SQLite, and Excel directly. Single binary, Python package, and 1.3 MB WASM build for the browser.
   - [chDB](https://chdb.io) - Embedded ClickHouse — full ClickHouse SQL dialect, ~80 data formats, and 12+ source connectors (S3, Postgres, MongoDB, Kafka, Iceberg) in core. Python, Go, Rust, Node, Bun, Zig, and Ruby bindings.
   - [zvec](https://github.com/alibaba/zvec) - An embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
+  - [Infino](https://github.com/infino-ai/infino) - An embedded retrieval engine that answers SQL, full-text (BM25), and vector queries over one copy of the data on object storage. Rows are stored as spec-compliant Parquet with the search indexes embedded in the files, so other Parquet readers can still open them. Rust, Python, and Node.js bindings.
 
 ## Data Comparison
 


### PR DESCRIPTION
Adds [Infino](https://github.com/infino-ai/infino) to Databases > Other, appended to the bottom of the category per the contributing guidelines.

It is an embedded retrieval engine (Apache-2.0, written in Rust) that answers SQL, full-text BM25, and vector queries over a single copy of the data on object storage, so a hybrid search setup does not need a separate vector store and search cluster kept in sync. Rows are stored as spec-compliant Parquet with the BM25 and vector indexes embedded in the files ahead of a standard footer, which means DuckDB, pyarrow, or anything else that reads Parquet can still open the same files.

It sits next to zvec, chDB, and SlothDB since it runs in-process rather than as a server. Published on crates.io, PyPI, and npm.

Unrelated heads-up: `npx awesome-lint` already fails on master with `List item description must start with valid casing` for the DBConvert Streams entry, whose description starts lowercase. It fails identically without my change, so CI here will likely be red for that reason. Happy to send a separate one-line PR for it.
