### PR TITLE
Add Seshat BI to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@
 - [DataScreenIQ](https://datascreeniq.com) - Real-time data quality firewall for pipelines and APIs. Screens rows in milliseconds for schema drift, null spikes, type mismatches, and data anomalies with PASS / WARN / BLOCK decisions.
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.
 - [Fixzi](https://fixzi.ai) - JSON/XML validation and API contract monitoring tool for debugging and testing structured data.
+- [Seshat BI](https://github.com/Kemetra/Seshat-BI) - Readiness governance for agent-built BI pipelines. Tracks every table across a seven-stage source-to-Power-BI spine, runs static checks over committed SQL, TMDL and PBIR text, and blocks each stage transition behind a recorded human approval so an AI agent cannot self-approve grain, PII or metric decisions. Ships a CLI plus a read-only MCP server.
 
 ## Community
 


### PR DESCRIPTION
Adds [Seshat BI](https://github.com/Kemetra/Seshat-BI) to the **Testing** category.

Open-source (Apache-2.0) readiness governance for BI pipelines built by AI agents. It tracks every table across a seven-stage source-to-Power-BI spine, runs static checks over committed SQL, TMDL and PBIR text, and holds each stage transition behind a recorded human approval — so an agent cannot self-approve grain, PII or metric decisions. Published on [PyPI](https://pypi.org/project/seshat-bi/).

Placed alongside the existing data-quality and governance entries (Aegis DQ, Grai, Provero, DQOps).

### Guidelines checklist
- [x] Searched for duplicates — not currently listed
- [x] Alphanumeric text only, no emojis or images
- [x] Added to the **bottom** of the relevant category
- [x] Individual pull request for this single suggestion
- [x] Format `[Name](link) - Description.`
- [x] Spelling and grammar checked
- [x] No trailing whitespace
- [x] Useful title on both the PR and the commit

Diff is a single added line.