### PR TITLE
fix: DexPaprika entry claims no rate limits and ~1s updates; both are wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@
 
 ### Realtime
 
-- [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data via SSE streaming across 36 blockchains. 36M+ pools, 33M+ tokens, swap-driven price updates. No API key needed; free tier is 200K requests/month. [Docs](https://docs.dexpaprika.com)
+- [DexPaprika](https://api.dexpaprika.com) - DEX data via SSE streaming across 36 blockchains. 36M+ pools, 33M+ tokens. Metered free tier, no API key required, data delayed up to 15s; real-time on the paid tier. [Docs](https://docs.dexpaprika.com)
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time financial data, 3.2M+ news articles, ML options pricing, and news bias analysis. Free, no API key. [MCP](https://heliumtrades.com/mcp)
 - [Twitter Realtime](https://developer.twitter.com/en/docs/tweets/filter-realtime/overview) - The Streaming APIs give developers low latency access to Twitter's global stream of Tweet data.
 - [Sorsa API](https://api.sorsa.io) - Real-time X (Twitter) data API providing tweets, profiles, search, communities and engagement metrics. Up to 50x cheaper than the official X API with 20 req/sec rate limit, JSON output.

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@
 
 ### Realtime
 
-- [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data via SSE streaming across 34 blockchains. 30M+ pools, 27M+ tokens, ~1 second price updates. No API key, no rate limits. [Docs](https://docs.dexpaprika.com)
+- [DexPaprika](https://api.dexpaprika.com) - Free real-time DEX data via SSE streaming across 36 blockchains. 36M+ pools, 33M+ tokens, swap-driven price updates. No API key needed; free tier is 200K requests/month. [Docs](https://docs.dexpaprika.com)
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time financial data, 3.2M+ news articles, ML options pricing, and news bias analysis. Free, no API key. [MCP](https://heliumtrades.com/mcp)
 - [Twitter Realtime](https://developer.twitter.com/en/docs/tweets/filter-realtime/overview) - The Streaming APIs give developers low latency access to Twitter's global stream of Tweet data.
 - [Sorsa API](https://api.sorsa.io) - Real-time X (Twitter) data API providing tweets, profiles, search, communities and engagement metrics. Up to 50x cheaper than the official X API with 20 req/sec rate limit, JSON output.


### PR DESCRIPTION
One line. I work on DexPaprika and this entry is from my own PR #232, so I am correcting my own claims.

**"no rate limits" is not true.** The free tier is metered: a monthly request allowance plus 30 requests per minute, and every stream update counts as a request. The entry now reads "metered free tier" and carries no number, since the allowance changed on 11 August. Current limits are in the docs the entry already links: https://docs.dexpaprika.com/knowledge-base/rate-limits. "No API key required" is true and stays.

**"~1 second price updates" is wrong.** Price frames follow trade activity rather than a fixed one second tick, and on the free tier they carry a documented delay of up to 15 seconds. I sampled WETH on Ethereum again today, about as busy as an ERC-20 gets, for 60 seconds:

```
$ curl -sN "https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
5 token_price frames in 60s
gaps: 13s, 11s, 13s, 12s
```

A quiet token on a quiet chain goes longer still. So the entry drops the cadence figure rather than swapping in another one, and states what a reader on this list actually needs: data delayed up to 15s on the free tier, real-time on the paid tier.

**The coverage numbers are a release behind.** The entry claims "34 blockchains", "30M+ pools" and "27M+ tokens". Live:

```
$ curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":235,"pools":38564883,"tokens":35483652}
```

I used the rounded published figures (36 chains, 36M+ pools, 33M+ tokens), not the exact live values, so the line does not need re-editing every time the index grows.

The entry stays in its current section and position. Nothing else in the file changes.