### PR TITLE
Add Manticore Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
   - [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - In-process analytical SQL database written in C++20. Reads Parquet, CSV, JSON, Avro, Arrow, SQLite, and Excel directly. Single binary, Python package, and 1.3 MB WASM build for the browser.
   - [chDB](https://chdb.io) - Embedded ClickHouse — full ClickHouse SQL dialect, ~80 data formats, and 12+ source connectors (S3, Postgres, MongoDB, Kafka, Iceberg) in core. Python, Go, Rust, Node, Bun, Zig, and Ruby bindings.
   - [zvec](https://github.com/alibaba/zvec) - An embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
+  - [Manticore Search](https://github.com/manticoresoftware/manticoresearch) - An open-source search database for full-text, vector, and hybrid search with real-time indexing and SQL.
 
 ## Data Comparison
 


### PR DESCRIPTION
Adds [Manticore Search](https://github.com/manticoresoftware/manticoresearch) to **Databases → Other**, at the bottom of the category as required by the contributing guidelines.

Manticore Search is a GPL-3.0 open-source search database for full-text, vector, and hybrid search with real-time indexing and SQL. This is an individual PR for one suggestion, with a one-sentence description and no unrelated changes.

Disclosure: I'm affiliated with the Manticore Search project.