### PR TITLE
Add Glyph library to Data Comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 - [koala-diff](https://github.com/godalida/koala-diff) - A high-performance Python library for comparing large datasets (CSV, Parquet) locally using Rust and Polars. It features zero-copy streaming to prevent OOM errors and generates interactive HTML data quality reports.
 - [FutureSearch SDK](https://github.com/futuresearch/futuresearch-python) - Python SDK that dispatches parallel web-research agents across
   table rows, synthesizing multi-agent findings into structured columns.
+- [Glyph](https://github.com/Koda-OSS/Glyph) - Framework-agnostic TypeScript library for generating, searching, and comparing MinHash fingerprints for fast text similarity, deduplication, and retrieval.
 
 ## Data Ingestion
 


### PR DESCRIPTION
## Description

Adds Glyph to the **Data Comparison** section.

Glyph is a framework-agnostic TypeScript library for generating, searching, and comparing MinHash fingerprints, with applications in text similarity, deduplication, and retrieval.

The project is open source and actively maintained.

## Checklist

* [x] Searched previous suggestions for duplicates
* [x] Added the entry to the bottom of the relevant category
* [x] Used a concise description
* [x] Checked spelling and grammar
* [x] Made this an individual pull request