### PR TITLE
Add Agent QA to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@
 
 ## Testing
 
+- [Agent QA](https://github.com/vostride/agent-qa) - Source-available agentic QA for natural-language web and mobile tests; an application-level companion rather than a data-quality engine.
 - [Aegis DQ](https://github.com/aegis-dq/aegis-dq) - Open-source agentic data quality framework with LLM-powered diagnosis, root-cause analysis, SQL auto-fix proposals, and 31 rule types — DuckDB, Postgres, BigQuery, Databricks, Athena, Snowflake.
 - [Grai](https://github.com/grai-io/grai-core/) - A data catalog tool that integrates into your CI system exposing downstream impact testing of data changes. These tests prevent data changes which might break data pipelines or BI dashboards from making it to production.
 - [DQOps](https://github.com/dqops/dqo) - An open-source data quality platform for the whole data platform lifecycle from profiling new data sources to applying full automation of data quality monitoring.


### PR DESCRIPTION
## Summary

Add Agent QA to Testing as an application-level QA companion.

The row explicitly distinguishes Agent QA from a data-quality engine: it runs natural-language web/mobile tests and is included as a broader testing tool around data products and their user-facing applications.

## Validation

- confirmed no duplicate entry or proposal
- `git diff --check` passes
- canonical project link returns HTTP 200

Disclosure: I am affiliated with Agent QA. Its current FSL-1.1-ALv2 release is source-available rather than OSI open source.
