### PR TITLE
feat: add dbt-ci to Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@
 - [SuprSend](https://www.suprsend.com/products/workflows) - Create automated workflows and logic using API's for your notification service. Add templates, batching, preferences, inapp inbox with workflows to trigger notifications directly from your data warehouse.
 - [Mage](https://www.mage.ai) - Open-source data pipeline tool for transforming and integrating data.
 - [SQLMesh](https://sqlmesh.readthedocs.io) - An open-source data transformation framework for managing, testing, and deploying SQL and Python-based data pipelines with version control, environment isolation, and automatic dependency resolution.
+- [dbt-ci](https://github.com/datablock-dev/dbt-ci) - State-based CI for dbt Core that runs only the changed models with a configurable downstream depth, drops deleted models from the warehouse, migrates changed BigQuery partitioning, and reports the change and exposure impact of every pull request.
 
 ## Data Lake Management
 


### PR DESCRIPTION
Adds [dbt-ci](https://github.com/datablock-dev/dbt-ci) to the Workflow category, alongside dbt and SQLMesh.

dbt-ci is an open-source (MIT) CI tool for dbt Core projects. It compares the current project against a reference state, then runs only the models that changed — with a configurable downstream depth so a change to a base model does not rebuild the entire graph. It also drops models deleted from the project out of the warehouse, rebuilds tables whose BigQuery partitioning config changed, and writes a change and exposure impact summary into the CI job summary.

Published on PyPI as `dbt-ci`.

Checklist:
- Searched the list for duplicates — no dbt CI entry exists
- Single suggestion in this pull request
- Added to the bottom of the relevant category
- Plain alphanumeric name and description, no emoji or images
- No trailing whitespace