### PR TITLE
Add Jitsu to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 - [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
+- [Jitsu](https://github.com/jitsucom/jitsu) - An open-source Customer Data Platform. Captures event data from websites, apps, and servers and streams it into ClickHouse, Snowflake, BigQuery, Redshift, Postgres, and MySQL in real time.
 
 ## File System
 


### PR DESCRIPTION
Adds [Jitsu](https://github.com/jitsucom/jitsu) to the Data Ingestion section.

Jitsu is an open-source Customer Data Platform (MIT, 5k+ stars) that captures event data from websites, apps, and servers and streams it into data warehouses in real time. It fits alongside the existing Airbyte, Meltano, Estuary Flow, and dlt entries, and complements RudderStack which is already listed under Workflow.

Supported warehouse destinations: ClickHouse, Snowflake, BigQuery, Redshift, Postgres, and MySQL.

One line added at the end of the Data Ingestion section, matching the existing entry format.