### PR TITLE
Add HighWater — self-hosted data freshness & quality monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Data Dumps](#data-dumps)
 - [Monitoring](#monitoring)
   - [Prometheus](#prometheus)
+  - [Data Monitoring](#data-monitoring)
 - [Profiling](#profiling)
   - [Data Profiler](#data-profiler)
 - [Schema](#schema)
@@ -365,6 +366,10 @@
 - [Prometheus.io](https://github.com/prometheus/prometheus) - An open-source service monitoring system and time series database.
 - [HAProxy Exporter](https://github.com/prometheus/haproxy_exporter) - Simple server that scrapes HAProxy stats and exports them via HTTP for Prometheus consumption.
 - [Signals CLI](https://github.com/sortlist/signals-cli) - Intent signal monitoring CLI. Track LinkedIn engagers, keyword posters, job changers, funding events. JSON output for data pipelines.
+
+### Data Monitoring
+
+- [HighWater](https://github.com/FrankFu916/highwater) - Self-hosted data freshness and quality monitoring: watches tables, APIs and files for staleness, schema drift, null spikes and volume anomalies. YAML checks, a live dashboard, Prometheus metrics and Slack/Discord/webhook alerts.
 
 ## Profiling
 


### PR DESCRIPTION
Adds [HighWater](https://github.com/FrankFu916/highwater) under Monitoring → Data Monitoring.

HighWater is a self-hosted data freshness & quality monitor: YAML checks watch tables (SQLite/Postgres/MySQL/ClickHouse), HTTP APIs and files for staleness, schema drift, null spikes and volume anomalies — with a live dashboard, Prometheus /metrics, and Slack/Discord/webhook alerts.

- MIT licensed, zero native dependencies (Node ≥22.5 built-in SQLite)
- `npx highwater demo` for a 30-second trial with realistic failing data
- v0.2.0, released 2026-08-26, actively maintained