### PR TITLE
Add FlexViz to Charts and Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [AI for Database](https://aifordatabase.com/) - Agentic AI platform to connect any database (PostgreSQL, MySQL, MongoDB, etc.) and query in plain English; includes self-refreshing intelligent dashboards and action workflows triggered by data changes.
 - [Dekart](https://github.com/dekart-xyz/dekart) - Open-source SQL to map platform for BigQuery, Snowflake, and PostGIS.
 - [LunaPad](https://lunapad.dev/) - Open-source analytics notebook for reusable SQL workflows, interactive reports, and AI-assisted data exploration.
+- [FlexViz](https://github.com/flex-analytics/flexviz) - Open-source Python library for interactive cross-filter dashboards on large datasets. Zoom, pan, and selection are answered by lazy Polars aggregations on a stateless server instead of sending rows to the browser.
 
 ## Workflow
 


### PR DESCRIPTION
Adds [FlexViz](https://github.com/flex-analytics/flexviz) to the bottom of the Charts and Dashboards category.

FlexViz is an Apache-2.0 Python library for interactive, cross-filtered dashboards over datasets that are too large to render client-side. Zoom, pan, and brush events are answered by lazy [Polars](https://github.com/pola-rs/polars) aggregations and Rust kernels on a stateless FastAPI server, so raw rows never reach the browser and charts stay interactive at 100M+ rows. It can also be mounted into an existing FastAPI app.

- Docs: https://docs.flexviz.tech
- Live demo (2 x 100M rows, no signup): https://flexviz.tech/demo.html
- Benchmarks: https://flexviz.tech/benchmarks.html
- PyPI: https://pypi.org/project/flexviz/

Note on CI: `npx awesome-lint` already fails on master with `README.md:150:53 List item description must start with valid casing` (the "DBConvert Streams" entry, lowercase "self-hosted"), unrelated to this change. My entry lints clean. Happy to fix line 150 in a separate PR if useful.

Disclosure: I am the author. Happy to adjust wording or placement.
