### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
   - [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database where agents branch and merge like Git. S3-native, Rust, traversal + vector + BM25 in one runtime.
   - [OrientDB](https://orientdb.com) - 2nd Generation Distributed Graph Database with the flexibility of Documents in one product with an Open Source commercial friendly license.
   - [ArangoDB](https://www.arangodb.com/) - A distributed free and open-source database with a flexible data model for documents, graphs, and key-values.
-  - [Titan](https://titan.thinkaurelius.com) - A scalable graph database optimized for storing and querying graphs containing hundreds of billions of vertices and edges distributed across a multi-machine cluster.
+  - [Titan](https://github.com/thinkaurelius/titan) - A scalable graph database optimized for storing and querying graphs containing hundreds of billions of vertices and edges distributed across a multi-machine cluster.
   - [FlockDB](https://github.com/twitter-archive/flockdb) - A distributed, fault-tolerant graph database by Twitter. Deprecated.
   - [Actionbase](https://github.com/kakao/actionbase) - A database for user interactions (likes, views, follows) represented as graphs, with precomputed reads served in real-time.
 - Distributed
@@ -200,7 +200,7 @@
 - [Apache ORC](https://orc.apache.org/) - The smallest, fastest columnar storage for Hadoop workloads.
 - [Apache Thrift](https://thrift.apache.org) - The Apache Thrift software framework, for scalable cross-language services development.
 - [ProtoBuf](https://github.com/protocolbuffers/protobuf) - Protocol Buffers - Google's data interchange format.
-- [SequenceFile](https://wiki.apache.org/hadoop/SequenceFile) - A flat file consisting of binary key/value pairs. It is extensively used in MapReduce as input/output formats.
+- [SequenceFile](https://cwiki.apache.org/confluence/display/HADOOP2/SequenceFile) - A flat file consisting of binary key/value pairs. It is extensively used in MapReduce as input/output formats.
 - [Kryo](https://github.com/EsotericSoftware/kryo) - A fast and efficient object graph serialization framework for Java.
 - [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing and DuckDB integration. Achieves ~9% compression ratio (better than gzip) with time-range random access queries.
 - [ParquetKit](https://parquetkit.com) - Browser-based viewer, SQL workbench and converter for Parquet files powered by DuckDB-WASM. Fully client-side, no upload.
@@ -217,7 +217,7 @@
 - [CocoIndex](https://github.com/cocoindex-io/cocoindex) - An open source ETL framework to build fresh index for AI. 
 - [VoltDB](https://voltdb.com/) - An ACID-compliant RDBMS which uses a [shared nothing architecture](https://en.wikipedia.org/wiki/Shared-nothing_architecture).
 - [PipelineDB](https://github.com/pipelinedb/pipelinedb) - The Streaming SQL Database.
-- [Spring Cloud Dataflow](https://cloud.spring.io/spring-cloud-dataflow/) - Streaming and tasks execution between Spring Boot apps.
+- [Spring Cloud Dataflow](https://dataflow.spring.io/) - Streaming and tasks execution between Spring Boot apps.
 - [Bonobo](https://www.bonobo-project.org/) - A data-processing toolkit for python 3.5+.
 - [Robinhood's Faust](https://github.com/faust-streaming/faust) - Forever scalable event processing & in-memory durable K/V store as a library with asyncio & static typing.
 - [HStreamDB](https://github.com/hstreamdb/hstream) - The streaming database built for IoT data storage and real-time processing.
@@ -289,7 +289,7 @@
 - [DataFlow](https://github.com/OpenDCAI/DataFlow) - Open-source platform for data preparation, synthetic data generation, and AI/data pipelines. Includes reusable skills for automating workflow steps across data and AI tasks.
 - [Luigi](https://github.com/spotify/luigi) - A Python module that helps you build complex pipelines of batch jobs.
 - [CronQ](https://github.com/seatgeek/cronq) - An application cron-like system. [Used](https://chairnerd.seatgeek.com/building-out-the-seatgeek-data-pipeline/) w/Luigi. Deprecated.
-- [Cascading](https://www.cascading.org/) - Java based application development platform.
+- [Cascading](https://cascading.wensel.net/) - Java based application development platform.
 - [Airflow](https://github.com/apache/airflow) - A system to programmatically author, schedule, and monitor data pipelines.
 - [Azkaban](https://azkaban.github.io/) - A batch workflow job scheduler created at LinkedIn to run Hadoop jobs. Azkaban resolves the ordering through job dependencies and provides an easy-to-use web user interface to maintain and track your workflows.
 - [Oozie](https://oozie.apache.org/) - A workflow scheduler system to manage Apache Hadoop jobs.
@@ -297,7 +297,7 @@
 - [Dagster](https://github.com/dagster-io/dagster) - An open-source Python library for building data applications.
 - [Hamilton](https://github.com/dagworks-inc/hamilton) - A lightweight library to define data transformations as a directed-acyclic graph (DAG). If you like dbt for SQL transforms, you will like Hamilton for Python processing.
 - [Kedro](https://kedro.readthedocs.io/en/latest/) - A framework that makes it easy to build robust and scalable data pipelines by providing uniform project templates, data abstraction, configuration and pipeline assembly.
-- [Dataform](https://dataform.co/) - An open-source framework and web based IDE to manage datasets and their dependencies. SQLX extends your existing SQL warehouse dialect to add features that support dependency management, testing, documentation and more.
+- [Dataform](https://github.com/dataform-co/dataform) - An open-source framework and web based IDE to manage datasets and their dependencies. SQLX extends your existing SQL warehouse dialect to add features that support dependency management, testing, documentation and more.
 - [Dotflow](https://github.com/dotflow-io/dotflow) - A lightweight Python library for building execution pipelines with retry, parallel execution, cron scheduling, and async support.
 - [Census](https://getcensus.com/) - A reverse-ETL tool that let you sync data from your cloud data warehouse to SaaS applications like Salesforce, Marketo, HubSpot, Zendesk, etc. No engineering favors required—just SQL.
 - [dbt](https://getdbt.com/) - A command line tool that enables data analysts and engineers to transform data in their warehouses more effectively.


### PR DESCRIPTION
Link-checked the README and fixed what is confirmed dead. Every dead URL was re-verified with curl (browser UA; NXDOMAIN double-checked via 8.8.8.8), and every replacement URL returns HTTP 200.

- `https://cloud.spring.io/spring-cloud-dataflow/` → `https://dataflow.spring.io/`
  - Old cloud.spring.io path is 404; https://dataflow.spring.io/ returns 200 with title 'Spring Cloud Dataflow UI' and is the homepage listed on the project's GitHub repo (spring-attic/spring-cloud-dataflow, OSS repo archived — project moved to commercial support).
- `https://dataform.co/` → `https://github.com/dataform-co/dataform`
  - dataform.co is NXDOMAIN (dig @8.8.8.8 empty; Dataform was acquired by Google). Official repo dataform-co/dataform exists via gh api, not archived, description 'Dataform is a framework for managing SQL based data operations in BigQuery' — matches the entry.
- `https://titan.thinkaurelius.com` → `https://github.com/thinkaurelius/titan`
  - Host titan.thinkaurelius.com is NXDOMAIN (dig @8.8.8.8 empty). Official project repo thinkaurelius/titan exists via gh api and is not archived (description 'Distributed Graph Database'); note the project is unmaintained since ~2015 and was continued as the JanusGraph fork.
- `https://wiki.apache.org/hadoop/SequenceFile` → `https://cwiki.apache.org/confluence/display/HADOOP2/SequenceFile`
  - Old MoinMoin wiki.apache.org is 404; the Hadoop wiki migrated to Confluence. New URL returns 200 with title 'SequenceFile - HADOOP2 - Apache Software Foundation' — same document.
- `https://www.cascading.org/` → `https://cascading.wensel.net/`
  - www.cascading.org is NXDOMAIN (dig @8.8.8.8 empty). The active repo cwensel/cascading (not archived, gh api) lists homepage cascading.wensel.net, which returns 200 with title 'Cascading | A feature rich Java API for complex data flows.'

The two entry removals (RancherOS, LatAm Synth) that were originally part of this PR are split out into a separate PR so they can be considered on their own.
