### PR TITLE
Add Big Data Log Analytics Platform to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 - [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
+- [Big Data Log Analytics Platform](https://github.com/mojtaba-py-code/big-data-log-analytics-platform) - Self-hosted streaming log pipeline that ingests files, directories, databases and paginated REST APIs into Hive-partitioned Parquet queried in place by DuckDB, with format auto-detection, a dead-letter queue, statistical anomaly detection and security analytics.
 
 ## File System
 


### PR DESCRIPTION
Adds an entry to **Data Ingestion**.

**Project:** https://github.com/mojtaba-py-code/big-data-log-analytics-platform

A self-hosted, open-source streaming log pipeline. It ingests from files, directories, PostgreSQL/MySQL/SQLite and paginated REST APIs, auto-detects the format (JSON/JSONL, Apache and Nginx logs, syslog RFC 3164/5424, logfmt, CSV/TSV, custom regex), and normalises everything onto one validated schema with a deterministic event ID so re-ingestion is idempotent. Output is Hive-partitioned Parquet (zstd) queried in place by DuckDB.

Ingestion is a chain of generators, so memory tracks the working set rather than the file: 4x the input costs 1.3x the peak RSS, measured by a benchmark harness that runs in CI. Unparseable records go to a dead-letter queue with a reason rather than being dropped.

MIT licensed. 604 tests, 87% coverage, `mypy --strict`, with `bandit`, `pip-audit` and CodeQL in CI.

Checklist against CONTRIBUTING:

- Searched the list first; not a duplicate
- Individual pull request for this one suggestion
- Alphanumeric text only, no emojis or images
- Added to the bottom of the relevant category
- `[Name](link) - Description.` format
- No trailing whitespace

Disclosure: I am the author of this project.
