### PR TITLE
Add Syncle to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 - [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
+- [Syncle](https://syncle.dev) - Self-hosted, GUI-driven sync between PostgreSQL, MySQL, SQLite, MongoDB and Redis in any combination, by one-off backfill, cursor polling, or change data capture read from the source's own change log.
 
 ## File System
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first, open-source desktop ETL/ELT studio: drag a pipeline onto a canvas (or describe it to a built-in on-device AI assistant) and run it at native speed through DuckDB. 290+ connectors, a scheduler, and an MCP server for driving pipelines from an LLM. No cloud, no servers.
 - [Rawbbit](https://github.com/mirlan-irokez/rawbbit) - Open-source self-hosted analytics pipeline that lands raw events as Parquet in your own object storage. Uses NATS JetStream for durable buffering and BigQuery external tables for querying. Designed for teams that want to own their raw event data.
 - [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
-- [Syncle](https://syncle.dev) - Self-hosted, GUI-driven sync between PostgreSQL, MySQL, SQLite, MongoDB and Redis in any combination, by one-off backfill, cursor polling, or change data capture read from the source's own change log.
+- [Syncle](https://github.com/osmanahmadxai/SYNCLE) - Open-source, self-hosted, GUI-driven sync between PostgreSQL, MySQL, SQLite, MongoDB and Redis in any combination, by one-off backfill, cursor polling, or change data capture read from the source's own change log.
 
 ## File System
 


### PR DESCRIPTION
Adds [Syncle](https://syncle.dev) to **Data Ingestion**, alongside entries like Airbyte, DBConvert Streams and Artie.

It moves rows between PostgreSQL, MySQL/MariaDB, SQLite, MongoDB and Redis in any combination. A bridge reads from a source table and writes to one or more destinations, fired one of three ways: a one-off backfill, a polling cursor, or change data capture read from the source's own change log — Postgres logical replication, MySQL binlog, MongoDB change streams, Redis keyspace notifications.

What distinguishes it from most of this section: there is no broker and no platform to stand up. It is four containers behind a single port with a web interface, aimed at one operator rather than a data team. Writes are idempotent upserts keyed by chosen columns, destination tables are created when missing with types translated across engines, and interrupted jobs resume from their cursor. HTTP endpoints work as a destination too.

Self-hosted, MIT licensed. Docs: https://syncle.dev/docs · Source: https://github.com/osmanahmadxai/SYNCLE