### PR TITLE
Add dbt-plan to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@
 - [RunSQL](https://runsql.com/) - Free online SQL playground for MySQL, PostgreSQL, and SQL Server. Create database structures, run queries, and share results instantly.
 - [Spark Playground](https://www.sparkplayground.com/) - Write, run, and test PySpark code on Spark Playground's online compiler. Access real-world sample datasets & solve interview questions to enhance your PySpark skills for data engineering roles.
 - [daffy](https://github.com/vertti/daffy/) - Decorator-first DataFrame contracts/validation (columns/dtypes/constraints) at function boundaries. Supports Pandas/Polars/PyArrow/Modin.
+- [dbt-plan](https://github.com/PresentJay/dbt-plan) - Terraform plan for dbt. Diffs compiled SQL between two revisions to predict the DDL a dbt run will emit, and fails the pull request on a dropped column or a downstream model it breaks. Reads files only, so it works against any warehouse without a connection.
 - [Snowflake Emulator](https://github.com/nnnkkk7/snowflake-emulator) - A Snowflake-compatible emulator for local development and testing.
 - [DataScreenIQ](https://datascreeniq.com) - Real-time data quality firewall for pipelines and APIs. Screens rows in milliseconds for schema drift, null spikes, type mismatches, and data anomalies with PASS / WARN / BLOCK decisions.
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.


### PR DESCRIPTION
[dbt-plan](https://github.com/PresentJay/dbt-plan) — one line added to the bottom of Testing.

Closest neighbour on the list is Grai, which exposes downstream impact of data changes in CI. dbt-plan answers the narrower question one layer down: *what DDL will this pull request actually execute?* It diffs compiled SQL between the base revision and the head, predicts the DDL from `materialization` × `on_schema_change`, and fails the check when a column is dropped — including when the break lands on a model downstream of the one that changed.

It reads `target/compiled/` and `manifest.json` and nothing else, so there is no warehouse connection and it behaves the same on Snowflake, BigQuery, Redshift, Postgres and DuckDB. Apache-2.0, `pip install dbt-plan`, one runtime dependency (sqlglot), also published as a GitHub Action.

One suggestion per PR per the contributing guidelines.