### PR TITLE
Add SqlInt to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 - [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and paths directly on DuckDB, Postgres, Snowflake, or ClickHouse.
 - [PyQtGraph](https://www.pyqtgraph.org/) - A pure-python graphics and GUI library built on PyQt4 / PySide and numpy. It is intended for use in mathematics / scientific / engineering applications.
 - [Seaborn](https://seaborn.pydata.org) - A Python visualization library based on matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
+- [SqlInt](https://sqlint.com) - Interactive SQL workspace featuring real-time JOIN visualizers, SQL query formatters, and practical database case studies.
 - [QueryGPT](https://github.com/MKY508/QueryGPT) - Natural language database query interface with automatic chart generation, supporting Chinese and English queries.
 - [AI for Database](https://aifordatabase.com/) - Agentic AI platform to connect any database (PostgreSQL, MySQL, MongoDB, etc.) and query in plain English; includes self-refreshing intelligent dashboards and action workflows triggered by data changes.
 - [Dekart](https://github.com/dekart-xyz/dekart) - Open-source SQL to map platform for BigQuery, Snowflake, and PostGIS.


### PR DESCRIPTION
### Description
Added SqlInt to the Charts and Dashboards section.

- Website: https://sqlint.com
- Overview: An interactive SQL workspace offering in-browser JOIN visualization, query formatting, and real-world database case studies.