### PR TITLE
Add dbmask to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@
 - [DataScreenIQ](https://datascreeniq.com) - Real-time data quality firewall for pipelines and APIs. Screens rows in milliseconds for schema drift, null spikes, type mismatches, and data anomalies with PASS / WARN / BLOCK decisions.
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.
 - [Fixzi](https://fixzi.ai) - JSON/XML validation and API contract monitoring tool for debugging and testing structured data.
+- [dbmask](https://github.com/sealandseacat/dbmask) - Open-source tool that scans SQL databases for sensitive columns, masks them with deterministic fakes, and validates the masked copy row by row against the original.
 
 ## Community
 


### PR DESCRIPTION
Adds dbmask (MIT, Python): scan → mask → validate workflow for making safe copies of SQL databases via SQLAlchemy. Detection is regex-first with an optional off-by-default LLM fallback; validation refuses to report PASS for anything it could not verify. I am the author.