### PR TITLE
Add Renart to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@
 - [faucet-stream](https://github.com/PawanSikawat/faucet-stream) - Config-driven data-movement platform for Rust with pluggable source and sink connectors, running ETL, CDC, and streaming pipelines declaratively from YAML or embedded as a library.
 - [Jitsu](https://github.com/jitsucom/jitsu) - An open-source Customer Data Platform. Captures event data from websites, apps, and servers and streams it into ClickHouse, Snowflake, BigQuery, Redshift, Postgres, and MySQL in real time.
 - [Scriptella ETL](https://github.com/scriptella/scriptella-etl) - Open-source, Java-based ETL and script execution tool for transferring and transforming data between databases, files, and other sources.
+- [Renart](https://github.com/renart-data/renart) - Local-first IDE for authoring and running SQL and Python data pipelines stored in Git.
 
 ## File System
 


### PR DESCRIPTION
Adds [Renart](https://github.com/renart-data/renart) to Data Ingestion, at the end of the category as requested by the contribution guidelines.

Renart is a local-first IDE for authoring and running SQL and Python pipelines from a Git repository. It fits this section because it combines extraction/loading with pipeline authoring and execution, while retaining plain SQL, Python and YAML files. The project is Apache-2.0 licensed and currently in public alpha.

Disclosure: I'm the creator of Renart. This submission was prepared with AI assistance.

I checked for previous Renart suggestions and found no existing entry or issue/PR. This change adds only one factual description and the canonical repository link.
