### PR TITLE
Fix awesome-lint error on master and add inclusion criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@
 - [Apache Pulsar](https://pulsar.apache.org/) - An open-source distributed pub-sub messaging system.
 - [AWS Data Wrangler](https://github.com/awslabs/aws-data-wrangler) - Utility belt to handle data on AWS.
 - [Airbyte](https://airbyte.io/) - Open-source data integration for modern data teams.
-- [DBConvert Streams](https://streams.dbconvert.com) - self-hosted database migration and change data capture (CDC) tool with built-in SQL IDE.
+- [DBConvert Streams](https://streams.dbconvert.com) - Self-hosted database migration and change data capture (CDC) tool with built-in SQL IDE.
 - [Artie](https://www.artie.com/) - Real-time data ingestion tool leveraging change data capture.
 - [Sling](https://slingdata.io/) - CLI data integration tool specialized in moving data between databases, as well as storage systems.
 - [Meltano](https://meltano.com/) - CLI & code-first ELT.

--- a/contributing.md
+++ b/contributing.md
@@ -17,3 +17,24 @@ Please ensure your pull request adheres to the following guidelines:
 
 Thank you for your suggestions!
 
+
+## Inclusion Criteria
+
+This is a curated list, not a directory. New entries should meet the following
+bar. If your submission does not yet, we are glad to look again once it does.
+
+- **On topic.** Data engineering infrastructure and tooling: databases,
+  ingestion, processing, orchestration, storage, quality, and datasets. Not
+  learning sites, interview preparation, general SaaS, or unrelated utilities.
+- **Used by someone other than the author.** Show it: stars, forks, outside
+  contributors, published packages, or tagged releases with a real changelog.
+- **Not brand new.** Projects should be at least 30 days old and still
+  maintained. A burst of commits followed by silence is not maintenance.
+- **Submitted by an established account.** Accounts created to make the
+  submission will be closed without further review.
+- **Described, not sold.** State what the tool does in one sentence. No
+  superlatives, no unverifiable claims ("fastest", "zero false positives").
+- **Licensed, if it is a repository.** Include a license file.
+
+AI-assisted development is fine and increasingly common. What we look for is
+evidence that the project is real and used, whoever or whatever wrote the code.


### PR DESCRIPTION
Two maintenance changes.

**Fix the lint error on master.** `npx awesome-lint` currently fails on `README.md:150` — the DBConvert Streams description starts with a lowercase "self-hosted". Since the failure is on master, the CI check is red on all ~38 open pull requests, so reviewers get no signal from it. Capitalizing the description brings the run to 0 errors. (7 spell-check *warnings* remain — `Postgres`, `WASM` — but those are non-blocking and appear inside product names and connector lists, so I left them alone.)

**Add inclusion criteria to contributing.md.** The file previously covered formatting only. The open queue has a large share of repositories that are days old with no users, no license, and no activity after the initial commit burst. The new section states the bar explicitly: on topic, used by someone other than the author, not brand new, from an established account, described rather than sold, and licensed.

It deliberately does not ban AI-assisted development — that is unenforceable and would exclude several good submissions. The signal we actually screen on is external validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)