### PR TITLE
Add DBConvert Parquet and JSONL viewers to Serialization format

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@
 - [Kryo](https://github.com/EsotericSoftware/kryo) - A fast and efficient object graph serialization framework for Java.
 - [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing and DuckDB integration. Achieves ~9% compression ratio (better than gzip) with time-range random access queries.
 - [ParquetKit](https://parquetkit.com) - Browser-based viewer, SQL workbench and converter for Parquet files powered by DuckDB-WASM. Fully client-side, no upload.
-- [DBConvert Parquet Viewer](https://streams.dbconvert.com/parquet-viewer) - Browser-based Parquet viewer on DuckDB-WASM: schema, row groups, compression codecs and column statistics, plus read-only SQL over the file and CSV export. Client-side, no upload; a JSONL/NDJSON viewer at /jsonl-viewer uses the same engine.
+- [DBConvert Parquet Viewer](https://streams.dbconvert.com/parquet-viewer) - Browser-based Parquet viewer on DuckDB-WASM: schema, row groups, compression codecs and column statistics, plus read-only SQL over the file and CSV export. Client-side, no upload.
+- [DBConvert JSONL Viewer](https://streams.dbconvert.com/jsonl-viewer) - Browser-based JSONL/NDJSON viewer on DuckDB-WASM: shows the file as a table with column types inferred across all lines, flags the lines that are not valid JSON, and runs read-only SQL. Client-side, no upload.
 
 ## Stream Processing
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@
 - [Kryo](https://github.com/EsotericSoftware/kryo) - A fast and efficient object graph serialization framework for Java.
 - [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing and DuckDB integration. Achieves ~9% compression ratio (better than gzip) with time-range random access queries.
 - [ParquetKit](https://parquetkit.com) - Browser-based viewer, SQL workbench and converter for Parquet files powered by DuckDB-WASM. Fully client-side, no upload.
+- [DBConvert Parquet Viewer](https://streams.dbconvert.com/parquet-viewer) - Browser-based Parquet viewer on DuckDB-WASM: schema, row groups, compression codecs and column statistics, plus read-only SQL over the file and CSV export. Client-side, no upload; a JSONL/NDJSON viewer at /jsonl-viewer uses the same engine.
 
 ## Stream Processing
 


### PR DESCRIPTION
Adds two browser-based viewers to `Serialization format`: one for Parquet, next to Apache Parquet and ParquetKit, and one for JSON Lines, next to PFC-JSONL. They are two separate tools that happen to share an engine (DuckDB-WASM), each with its own page, so they are listed as two entries.

Disclosure: I work on DBConvert, these are our own tools.

DBConvert Streams is already listed under Data Ingestion - that entry is the self-hosted migration/CDC platform. These are separate: pages that open a local file in the browser with nothing installed and no account, which is why they sit with the format tooling instead. Happy to drop one or both if you keep one entry per vendor.

Parquet Viewer reads the schema, row groups, compression codecs and column statistics, runs read-only SQL over the file (DuckDB `read_parquet`), and exports results as CSV. JSONL Viewer renders a `.jsonl` / `.ndjson` file as a table with column types inferred across the whole file, flags the lines that fail to parse, and runs read-only SQL over the valid records. In both cases the file is registered as a browser file handle and never uploaded.

Both URLs work without authentication.