### PR TITLE
Remove two defunct entries (RancherOS, LatAm Synth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@
 
 - [Gockerize](https://github.com/redbooth/gockerize) - Package golang service into minimal Docker containers.
 - [Flocker](https://github.com/ClusterHQ/flocker) - Easily manage Docker containers & their data.
-- [Rancher](https://rancher.com/rancher-os/) - RancherOS is a 20mb Linux distro that runs the entire OS as Docker containers.
 - [Kontena](https://www.kontena.io/) - Application Containers for Masses.
 - [Weave](https://github.com/weaveworks/weave) - Weaving Docker containers into applications.
 - [Zodiac](https://github.com/CenturyLinkLabs/zodiac) - A lightweight tool for easy deployment and rollback of dockerized applications.
@@ -360,7 +359,6 @@
 - [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite of US household cost burdens (housing, taxes, childcare, healthcare, transport) aggregated from Census ACS, BLS Consumer Expenditure Survey, and HUD Fair Market Rents. Open methodology, free, no email gate.
 - [FirstData](https://github.com/MLT-OSS/FirstData) - The world's most comprehensive authoritative data source knowledge base. 160+ curated sources from governments, international organizations, and research institutions with MCP integration.
 - [Mindweave Synthetic Business Data](https://github.com/MindweaveTech/sme-sim-sample) - 42-table synthetic SME dataset with double-entry accounting, tax compliance (AU/US/UK), and temporal realism. CSV, SQL, Parquet, SQLite. Ideal for ETL pipeline testing.
-- [LatAm Synth](https://apify.com/jmendozapuche/latam-synth) - Synthetic financial savings behavior generator for Latin America: users, savings goals, and transactions calibrated on 506K real records (2015–2024). Reproducible by seed, 100% synthetic.
 
 ## Monitoring
 


### PR DESCRIPTION
Split out of #351 at the maintainer's request so the removals can be considered separately from the link fixes.

Two entries whose targets no longer exist (re-verified today with curl, browser UA):

- **Rancher** — `https://rancher.com/rancher-os/` returns HTTP 404. RancherOS reached end-of-life and its GitHub repo `rancher/os` is archived, so there is no live page to point the entry at.
- **LatAm Synth** — the Apify actor `https://apify.com/jmendozapuche/latam-synth` returns HTTP 404, and the whole account `https://apify.com/jmendozapuche` is 404 as well; no new address found.

Happy to keep either entry with a different link if you know of one.
