### PR TITLE
Add Upstrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@
 - [DataDriven](https://www.datadriven.io/) - Interview practice with SQL query execution, Python, and data modeling exercises.
 - [Fixzi](https://fixzi.ai) - JSON/XML validation and API contract monitoring tool for debugging and testing structured data.
 - [dbmask](https://github.com/sealandseacat/dbmask) - Open-source tool that scans SQL databases for sensitive columns, masks them with deterministic fakes, and validates the masked copy row by row against the original.
+- [Upstrace](https://github.com/ashg2099/upstrace) - Column-level drift detection and lineage-based root-cause analysis for dbt projects.
 
 ## Community
 


### PR DESCRIPTION
Adds Upstrace — an open-source tool that profiles every column of a dbt project per partition, detects drift, and uses the manifest lineage graph to name the root-cause node rather than alerting on every affected model.

`pip install upstrace` · MIT-licensed · benchmarked against 56 injected fault scenarios with 4 negative controls.